### PR TITLE
[CHORE] 스웨거 설정, ApiControllerAdvice -> GlobalExceptionHandler 클래스명 변경

### DIFF
--- a/src/main/java/depth/mju/council/global/config/SwaggerConfig.java
+++ b/src/main/java/depth/mju/council/global/config/SwaggerConfig.java
@@ -1,0 +1,23 @@
+package depth.mju.council.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components())
+                .info(apiInfo());
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("총학 홈페이지 공모전 API")
+                .version("1.0.0");
+    }
+}

--- a/src/main/java/depth/mju/council/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/depth/mju/council/global/error/GlobalExceptionHandler.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice(annotations = RestController.class)
-public class ApiControllerAdvice {
+public class GlobalExceptionHandler {
 
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
     protected ResponseEntity<?> handleHttpRequestMethodNotSupportedException(


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

- [x] 스웨거 설정파일 추가 
- [x] ApiControllerAdvice -> GlobalExceptionHandler

### 📷 스크린샷
> 작업 화면(피그마, 웹사이트 등) 및 실행 결과를 캡쳐해주세요
![image](https://github.com/user-attachments/assets/d9e78819-c905-4aae-9d89-b0474a9faf7f)


## #️⃣ 연관된 이슈
> ex) # 이슈번호


## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 예외 처리를 이렇게 해도 괜찮을까요? / ~~부분 주의 깊게 봐주세요

기존의 ApiControllerAdvice 클래스는 API 개발과 관련된 예외 뿐만 아니라 시스템 전체에서 발생되는 예외도 함께 다루고 있으며, API 관련/로직 관련 예외는 DefaultException 및 Error Code를 이용해 예외 처리하고있습니다. 따라서 GlobalExceptionHandler라는 이름이 더 직관적이라고 판단했으며 디스코드에서 논의함에 따라 위와 같이 변경합니다.

Swagger의 경우 카테고리화나 더 자세한 명세가 필요하다고 생각되면 코멘트/디코 남겨주세요.
