### PR TITLE
[FEAT] 중운위(단과대) API 구현

### DIFF
--- a/src/main/java/depth/mju/council/domain/committe/controller/CommitteeController.java
+++ b/src/main/java/depth/mju/council/domain/committe/controller/CommitteeController.java
@@ -1,11 +1,15 @@
 package depth.mju.council.domain.committe.controller;
 
 import depth.mju.council.domain.committe.service.CommitteeService;
+import depth.mju.council.domain.committe.dto.req.CreateCommitteeReq;
+import depth.mju.council.global.config.UserPrincipal;
 import depth.mju.council.global.payload.ApiResult;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/v1/committees")
@@ -22,5 +26,20 @@ public class CommitteeController {
                 .message("중운위(단과대)를 성공적으로 조회했습니다.")
                 .build();
         return ResponseEntity.ok(apiResult);
+    }
+
+    @Operation(summary = "중운위(단과대) 등록")
+    @PostMapping("")
+    public ResponseEntity<?> createCommittee(
+            @RequestPart("request") CreateCommitteeReq request,
+            @RequestPart("image") MultipartFile image,
+            @AuthenticationPrincipal UserPrincipal userPrincipal) {
+        committeeService.createCommittee(request, image, userPrincipal);
+        return ResponseEntity.ok(
+                ApiResult.builder()
+                        .check(true)
+                        .message("중운위(단과대)가 등록되었습니다.")
+                        .build()
+        );
     }
 }

--- a/src/main/java/depth/mju/council/domain/committe/controller/CommitteeController.java
+++ b/src/main/java/depth/mju/council/domain/committe/controller/CommitteeController.java
@@ -42,4 +42,20 @@ public class CommitteeController {
                         .build()
         );
     }
+
+    @Operation(summary = "중운위(단과대) 수정")
+    @PutMapping("/{committeeId}")
+    public ResponseEntity<?> updateCommittee(
+            @PathVariable Long committeeId,
+            @RequestPart("request") CreateCommitteeReq request,
+            @RequestPart("image") MultipartFile image,
+            @AuthenticationPrincipal UserPrincipal userPrincipal) {
+        committeeService.updateCommittee(committeeId, request, image, userPrincipal);
+        return ResponseEntity.ok(
+                ApiResult.builder()
+                        .check(true)
+                        .message("중운위(단과대)가 수정되었습니다.")
+                        .build()
+        );
+    }
 }

--- a/src/main/java/depth/mju/council/domain/committe/controller/CommitteeController.java
+++ b/src/main/java/depth/mju/council/domain/committe/controller/CommitteeController.java
@@ -58,4 +58,17 @@ public class CommitteeController {
                         .build()
         );
     }
+
+    @Operation(summary = "중운위(단과대) 삭제")
+    @DeleteMapping("/{committeeId}")
+    public ResponseEntity<?> deleteCommittee(@PathVariable Long committeeId,
+                                             @AuthenticationPrincipal UserPrincipal userPrincipal) {
+        committeeService.deleteCommittee(committeeId, userPrincipal);
+        return ResponseEntity.ok(
+                ApiResult.builder()
+                        .check(true)
+                        .message("중운위(단과대)가 삭제되었습니다.")
+                        .build()
+        );
+    }
 }

--- a/src/main/java/depth/mju/council/domain/committe/controller/CommitteeController.java
+++ b/src/main/java/depth/mju/council/domain/committe/controller/CommitteeController.java
@@ -1,13 +1,26 @@
 package depth.mju.council.domain.committe.controller;
 
 import depth.mju.council.domain.committe.service.CommitteeService;
+import depth.mju.council.global.payload.ApiResult;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/committees")
+@RequestMapping("/api/v1/committees")
 @RequiredArgsConstructor
 public class CommitteeController {
     private final CommitteeService committeeService;
+
+    @Operation(summary = "중운위(단과대) 조회")
+    @GetMapping("")
+    public ResponseEntity<ApiResult> getAllCommittees() {
+        ApiResult apiResult = ApiResult.builder()
+                .check(true)
+                .information(committeeService.getAllCommittees())
+                .message("중운위(단과대)를 성공적으로 조회했습니다.")
+                .build();
+        return ResponseEntity.ok(apiResult);
+    }
 }

--- a/src/main/java/depth/mju/council/domain/committe/dto/req/CreateCommitteeReq.java
+++ b/src/main/java/depth/mju/council/domain/committe/dto/req/CreateCommitteeReq.java
@@ -1,0 +1,31 @@
+package depth.mju.council.domain.committe.dto.req;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class CreateCommitteeReq {
+
+    @Schema(type = "String", example = "중앙운영위원회는 총학생회장, 부총학생회장, 단과대학 학생회장 및 대표자, 총동아리 연합회장 및 대표자로 구성됩니다.",
+            description = "중운위 설명. 단과대는 null로 전송해주세요.")
+    public String description;
+
+    @Schema(type = "String", example = "ICT융합대학", description = "단과대명. 중운위는 null로 전송해주세요.")
+    public String college;
+
+    @Schema(type = "String", example = "새솔", description = "학생회명. 중운위는 null로 전송해주세요.")
+    public String name;
+
+    @Schema(type = "String", example = "홈페이지 주소", description = "홈페이지 주소. 중운위는 null로 전송해주세요.")
+    public String pageUrl;
+
+    @Schema(type = "String", example = "인스타 주소", description = "인스타 주소. 중운위는 null로 전송해주세요.")
+    public String snsUrl;
+
+}

--- a/src/main/java/depth/mju/council/domain/committe/dto/res/CommitteeRes.java
+++ b/src/main/java/depth/mju/council/domain/committe/dto/res/CommitteeRes.java
@@ -1,0 +1,37 @@
+package depth.mju.council.domain.committe.dto.res;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@RequiredArgsConstructor
+public class CommitteeRes {
+
+    @Schema(type = "Long", example = "1", description = "중운위(단과대) ID")
+    public Long committeeId;
+
+    @Schema(type = "String", example = "중앙운영위원회는 총학생회장, 부총학생회장, 단과대학 학생회장 및 대표자, 총동아리 연합회장 및 대표자로 구성됩니다.",
+            description = "중운위 설명. 단과대는 null로 반환")
+    public String description;
+
+    @Schema(type = "String", example = "ICT융합대학", description = "단과대명. 중운위는 null로 반환")
+    public String college;
+
+    @Schema(type = "String", example = "새솔", description = "학생회명. 중운위는 null로 반환")
+    public String name;
+
+    @Schema(type = "String", example = "홈페이지 주소", description = "홈페이지 주소. 중운위는 null로 반환")
+    public String pageUrl;
+
+    @Schema(type = "String", example = "인스타 주소", description = "인스타 주소. 중운위는 null로 반환")
+    public String snsUrl;
+
+    @Schema(type = "String", example = "https://council-s3-bucket.s3.amazonaws.com/image/79fdc2c6-02e42b-ffb2fde8b189.png", description = "이미지 주소")
+    public String imgUrl;
+
+}

--- a/src/main/java/depth/mju/council/domain/committe/entity/Committee.java
+++ b/src/main/java/depth/mju/council/domain/committe/entity/Committee.java
@@ -3,10 +3,16 @@ package depth.mju.council.domain.committe.entity;
 import depth.mju.council.domain.user.entity.UserEntity;
 import depth.mju.council.domain.common.BaseEntity;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
 @Entity
+@Builder
+@AllArgsConstructor
+@RequiredArgsConstructor
 @Table(name = "committee")
 public class Committee extends BaseEntity {
     @Id

--- a/src/main/java/depth/mju/council/domain/committe/entity/Committee.java
+++ b/src/main/java/depth/mju/council/domain/committe/entity/Committee.java
@@ -31,4 +31,13 @@ public class Committee extends BaseEntity {
     @ManyToOne
     @JoinColumn(name = "user_id", nullable = false)
     private UserEntity userEntity;
+
+    public void update(String description, String college, String name, String pageUrl, String snsUrl, String imgUrl) {
+        this.description = description;
+        this.college = college;
+        this.name = name;
+        this.pageUrl = pageUrl;
+        this.snsUrl = snsUrl;
+        this.imgUrl = imgUrl;
+    }
 }

--- a/src/main/java/depth/mju/council/domain/committe/repository/CommitteeRepository.java
+++ b/src/main/java/depth/mju/council/domain/committe/repository/CommitteeRepository.java
@@ -1,0 +1,9 @@
+package depth.mju.council.domain.committe.repository;
+
+import depth.mju.council.domain.committe.entity.Committee;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CommitteeRepository extends JpaRepository<Committee, Long> {
+}

--- a/src/main/java/depth/mju/council/domain/committe/service/CommitteeService.java
+++ b/src/main/java/depth/mju/council/domain/committe/service/CommitteeService.java
@@ -1,9 +1,33 @@
 package depth.mju.council.domain.committe.service;
 
+import depth.mju.council.domain.committe.dto.res.CommitteeRes;
+import depth.mju.council.domain.committe.entity.Committee;
+import depth.mju.council.domain.committe.repository.CommitteeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class CommitteeService {
+    private final CommitteeRepository committeeRepository;
+
+    @Transactional(readOnly = true)
+    public List<CommitteeRes> getAllCommittees() {
+        List<Committee> committees = committeeRepository.findAll();
+
+        return committees.stream()
+                .map(committee -> CommitteeRes.builder()
+                        .committeeId(committee.getId())
+                        .description(committee.getDescription())
+                        .college(committee.getCollege())
+                        .name(committee.getName())
+                        .pageUrl(committee.getPageUrl())
+                        .snsUrl(committee.getSnsUrl())
+                        .imgUrl(committee.getImgUrl())
+                        .build())
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/depth/mju/council/domain/committe/service/CommitteeService.java
+++ b/src/main/java/depth/mju/council/domain/committe/service/CommitteeService.java
@@ -3,9 +3,18 @@ package depth.mju.council.domain.committe.service;
 import depth.mju.council.domain.committe.dto.res.CommitteeRes;
 import depth.mju.council.domain.committe.entity.Committee;
 import depth.mju.council.domain.committe.repository.CommitteeRepository;
+import depth.mju.council.domain.committe.dto.req.CreateCommitteeReq;
+import depth.mju.council.domain.user.entity.UserEntity;
+import depth.mju.council.domain.user.repository.UserRepository;
+import depth.mju.council.global.config.UserPrincipal;
+import depth.mju.council.global.error.DefaultException;
+import depth.mju.council.global.payload.ErrorCode;
+import depth.mju.council.infrastructure.s3.service.S3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -13,6 +22,8 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class CommitteeService {
     private final CommitteeRepository committeeRepository;
+    private final UserRepository userRepository;
+    private final S3Service s3Service;
 
     @Transactional(readOnly = true)
     public List<CommitteeRes> getAllCommittees() {
@@ -29,5 +40,23 @@ public class CommitteeService {
                         .imgUrl(committee.getImgUrl())
                         .build())
                 .collect(Collectors.toList());
+    }
+
+    //현재 하나씩 저장 // 여러개씩 저장으로 바뀔 수도 있음 (소개이미지, 조직도, 국별업무, 중운위에 해당)
+    @Transactional
+    public void createCommittee(CreateCommitteeReq request, MultipartFile image, UserPrincipal userPrincipal) {
+        UserEntity user = userRepository.findById(userPrincipal.getId())
+                .orElseThrow(() -> new DefaultException(ErrorCode.USER_NOT_FOUND));
+
+        Committee committee = Committee.builder()
+                .description(request.description)
+                .college(request.college)
+                .name(request.name)
+                .pageUrl(request.pageUrl)
+                .snsUrl(request.snsUrl)
+                .imgUrl(s3Service.uploadImage(image))
+                .userEntity(user)
+                .build();
+        committeeRepository.save(committee);
     }
 }

--- a/src/main/java/depth/mju/council/domain/committe/service/CommitteeService.java
+++ b/src/main/java/depth/mju/council/domain/committe/service/CommitteeService.java
@@ -82,4 +82,22 @@ public class CommitteeService {
 
         committeeRepository.save(committee);
     }
+
+    @Transactional
+    public void deleteCommittee(Long committeeId, UserPrincipal userPrincipal) {
+        Committee committee = committeeRepository.findById(committeeId)
+                .orElseThrow(() -> new DefaultException(ErrorCode.CONTENTS_NOT_FOUND, "중운위(단과대)를 찾을 수 없습니다."));
+        userRepository.findById(userPrincipal.getId())
+                .orElseThrow(() -> new DefaultException(ErrorCode.USER_NOT_FOUND));
+
+        // 이미지 삭제
+        String imageUrl = committee.getImgUrl();
+        if (imageUrl != null) {
+            String imageName = s3Service.extractImageNameFromUrl(imageUrl);
+            s3Service.deleteImage(imageName);
+        }
+
+        // 중운위(단과대) 삭제
+        committeeRepository.delete(committee);
+    }
 }


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

- [x] 중운위(단과대) 조회 
- [x] 중운위(단과대) 등록
- [x] 중운위(단과대) 수정
- [x] 중운위(단과대) 삭제

### 📷 스크린샷
> 작업 화면(피그마, 웹사이트 등) 및 실행 결과를 캡쳐해주세요
![image](https://github.com/user-attachments/assets/69d7e75a-83b5-412b-b617-25e1830496fe)


## #️⃣ 연관된 이슈
> ex) # 이슈번호
#25

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 예외 처리를 이렇게 해도 괜찮을까요? / ~~부분 주의 깊게 봐주세요

API 명세 작성 당시에는 중운위/단과대가 같은 페이지에서 관리(등록, 수정, 조회)하게끔 되어 있어서 같은 엔티티로 각각 필요한 값 외에는 null로 저장/조회되게+웹에서 첫번째는 중운위로 요청하게끔 명세했는데, 
구현하다보니 중운위와 단과대 순서가 반드시 보장되지 않아서 1) 엔티티를 분리하거나 2) 중운위/단과대를 구분하는 컬럼 추가 및 예외(또는 정렬) 추가 
두 방식을 고려중입니다. 지금 방식 그대로 괜찮다거나 상기한 방식, 또는 새로운 다른 좋은 방식이 있으면 코멘트 달아주세요!

그리고 등록/수정하는 dto가 똑같아서 create할 때 쓴 req dto를 수정API에서도 재사용했는데 CreateCommitteeReq라는 이름 외에 좋은 이름이 있을까요?.. 😺