### PR TITLE
[FEAT] 국별 소개 API 구현/조직도 API 및 시큐리티 설정 변경

### DIFF
--- a/src/main/java/depth/mju/council/domain/department/controller/DepartmentController.java
+++ b/src/main/java/depth/mju/council/domain/department/controller/DepartmentController.java
@@ -1,13 +1,29 @@
 package depth.mju.council.domain.department.controller;
 
 import depth.mju.council.domain.department.service.DepartmentService;
+import depth.mju.council.global.config.UserPrincipal;
+import depth.mju.council.global.payload.ApiResult;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
-@RequestMapping("/api/departments")
+@RequestMapping("/api/v1/departments")
 @RequiredArgsConstructor
 public class DepartmentController {
     private final DepartmentService departmentService;
-}
+
+    @Operation(summary = "국별 소개 조회")
+    @GetMapping("")
+    public ResponseEntity<ApiResult> getAllDepartments() {
+        ApiResult apiResult = ApiResult.builder()
+                .check(true)
+                .information(departmentService.getAllDepartments())
+                .message("국별 소개를 성공적으로 조회했습니다.")
+                .build();
+        return ResponseEntity.ok(apiResult);
+    }
+

--- a/src/main/java/depth/mju/council/domain/department/controller/DepartmentController.java
+++ b/src/main/java/depth/mju/council/domain/department/controller/DepartmentController.java
@@ -27,3 +27,18 @@ public class DepartmentController {
         return ResponseEntity.ok(apiResult);
     }
 
+    @Operation(summary = "국별 소개 등록")
+    @PostMapping("")
+    public ResponseEntity<?> createDepartments(
+            @RequestPart("description") String description,
+            @RequestPart(value = "image", required = false) MultipartFile image,
+            @AuthenticationPrincipal UserPrincipal userPrincipal) {
+        departmentService.createDepartment(description, image, userPrincipal);
+        return ResponseEntity.ok(
+                ApiResult.builder()
+                        .check(true)
+                        .message("국별 소개가 등록되었습니다.")
+                        .build()
+        );
+    }
+

--- a/src/main/java/depth/mju/council/domain/department/controller/DepartmentController.java
+++ b/src/main/java/depth/mju/council/domain/department/controller/DepartmentController.java
@@ -42,3 +42,18 @@ public class DepartmentController {
         );
     }
 
+    @Operation(summary = "국별 소개 수정")
+    @PutMapping("/{departmentId}")
+    public ResponseEntity<?> updateDepartment(
+            @PathVariable Long departmentId,
+            @RequestPart("description") String description,
+            @RequestPart(value = "image", required = false) MultipartFile image,
+            @AuthenticationPrincipal UserPrincipal userPrincipal) {
+        departmentService.updateDepartment(departmentId, description, image, userPrincipal);
+        return ResponseEntity.ok(
+                ApiResult.builder()
+                        .check(true)
+                        .message("국별 소개가 수정되었습니다.")
+                        .build()
+        );
+    }

--- a/src/main/java/depth/mju/council/domain/department/controller/DepartmentController.java
+++ b/src/main/java/depth/mju/council/domain/department/controller/DepartmentController.java
@@ -57,3 +57,17 @@ public class DepartmentController {
                         .build()
         );
     }
+
+    @Operation(summary = "국별 소개 삭제")
+    @DeleteMapping("/{departmentId}")
+    public ResponseEntity<?> deleteDepartment(@PathVariable Long departmentId,
+                                              @AuthenticationPrincipal UserPrincipal userPrincipal) {
+        departmentService.deleteDepartment(departmentId, userPrincipal);
+        return ResponseEntity.ok(
+                ApiResult.builder()
+                        .check(true)
+                        .message("국별 소개가 삭제되었습니다.")
+                        .build()
+        );
+    }
+}

--- a/src/main/java/depth/mju/council/domain/department/dto/res/DepartmentRes.java
+++ b/src/main/java/depth/mju/council/domain/department/dto/res/DepartmentRes.java
@@ -1,0 +1,24 @@
+package depth.mju.council.domain.department.dto.res;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@RequiredArgsConstructor
+public class DepartmentRes {
+
+    @Schema(type = "Long", example = "1", description = "국별 소개 ID")
+    public Long departmentId;
+
+    @Schema(type = "String", example = "제휴나 외부 업체와의 소통을 담당합니다.", description = "국별 업무 소개글.")
+    public String description;
+
+    @Schema(type = "String", example = "https://council-s3-bucket.s3.amazonaws.com/image/79fdc2c6-02e42b-ffb2fde8b189.png", description = "이미지/파일의 주소")
+    public String imgUrl;
+
+}

--- a/src/main/java/depth/mju/council/domain/department/entity/Department.java
+++ b/src/main/java/depth/mju/council/domain/department/entity/Department.java
@@ -1,12 +1,18 @@
 package depth.mju.council.domain.department.entity;
 
-import depth.mju.council.domain.user.entity.UserEntity;
 import depth.mju.council.domain.common.BaseEntity;
+import depth.mju.council.domain.user.entity.UserEntity;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
 @Entity
+@Builder
+@AllArgsConstructor
+@RequiredArgsConstructor
 @Table(name = "department")
 public class Department extends BaseEntity {
     @Id
@@ -21,4 +27,9 @@ public class Department extends BaseEntity {
     @ManyToOne
     @JoinColumn(name = "user_id", nullable = false)
     private UserEntity userEntity;
+
+    public void updateDescriptionAndImgUrl(String description, String newImageUrl) {
+        this.description = description;
+        this.imgUrl = imgUrl;
+    }
 }

--- a/src/main/java/depth/mju/council/domain/department/repository/DepartmentRepository.java
+++ b/src/main/java/depth/mju/council/domain/department/repository/DepartmentRepository.java
@@ -1,0 +1,9 @@
+package depth.mju.council.domain.department.repository;
+
+import depth.mju.council.domain.department.entity.Department;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DepartmentRepository extends JpaRepository<Department, Long> {
+}

--- a/src/main/java/depth/mju/council/domain/department/service/DepartmentService.java
+++ b/src/main/java/depth/mju/council/domain/department/service/DepartmentService.java
@@ -1,9 +1,40 @@
 package depth.mju.council.domain.department.service;
 
+import depth.mju.council.domain.department.dto.res.DepartmentRes;
+import depth.mju.council.domain.department.entity.Department;
+import depth.mju.council.domain.department.repository.DepartmentRepository;
+import depth.mju.council.domain.user.entity.UserEntity;
+import depth.mju.council.domain.user.repository.UserRepository;
+import depth.mju.council.global.config.UserPrincipal;
+import depth.mju.council.global.error.DefaultException;
+import depth.mju.council.global.payload.ErrorCode;
+import depth.mju.council.infrastructure.s3.service.S3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class DepartmentService {
+    private final DepartmentRepository departmentRepository;
+    private final UserRepository userRepository;
+    private final S3Service s3Service;
+
+    @Transactional(readOnly = true)
+    public List<DepartmentRes> getAllDepartments() {
+        List<Department> departments = departmentRepository.findAll();
+
+        return departments.stream()
+                .map(department -> DepartmentRes.builder()
+                        .departmentId(department.getId())
+                        .description(department.getDescription())
+                        .imgUrl(department.getImgUrl())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
 }

--- a/src/main/java/depth/mju/council/domain/department/service/DepartmentService.java
+++ b/src/main/java/depth/mju/council/domain/department/service/DepartmentService.java
@@ -70,4 +70,22 @@ public class DepartmentService {
 
         departmentRepository.save(department);
     }
+
+    @Transactional
+    public void deleteDepartment(Long departmentId, UserPrincipal userPrincipal) {
+        Department department = departmentRepository.findById(departmentId)
+                .orElseThrow(() -> new DefaultException(ErrorCode.CONTENTS_NOT_FOUND, "국 별 소개를 찾을 수 없습니다."));
+        userRepository.findById(userPrincipal.getId())
+                .orElseThrow(() -> new DefaultException(ErrorCode.USER_NOT_FOUND));
+
+        // 이미지 삭제
+        String imageUrl = department.getImgUrl();
+        if (imageUrl != null) {
+            String imageName = s3Service.extractImageNameFromUrl(imageUrl);
+            s3Service.deleteImage(imageName);
+        }
+
+        // 국별 소개 삭제
+        departmentRepository.delete(department);
+    }
 }

--- a/src/main/java/depth/mju/council/domain/department/service/DepartmentService.java
+++ b/src/main/java/depth/mju/council/domain/department/service/DepartmentService.java
@@ -37,4 +37,18 @@ public class DepartmentService {
                 .collect(Collectors.toList());
     }
 
+    @Transactional
+    public void createDepartment(String description, MultipartFile image, UserPrincipal userPrincipal) {
+        UserEntity user = userRepository.findById(userPrincipal.getId())
+                .orElseThrow(() -> new DefaultException(ErrorCode.USER_NOT_FOUND));
+
+        String imgUrl = s3Service.uploadImage(image);
+        Department department = Department.builder()
+                .description(description)
+                .imgUrl(imgUrl)
+                .userEntity(user)
+                .build();
+        departmentRepository.save(department);
+    }
+
 }

--- a/src/main/java/depth/mju/council/domain/orgarnization/controller/OrganizationController.java
+++ b/src/main/java/depth/mju/council/domain/orgarnization/controller/OrganizationController.java
@@ -10,8 +10,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-
 @RestController
 @RequestMapping("/api/v1/organizations")
 @RequiredArgsConstructor
@@ -32,10 +30,10 @@ public class OrganizationController {
     @Operation(summary = "조직도 등록")
     @PostMapping("")
     public ResponseEntity<?> createOrganization(
-            @RequestPart("titles") List<String> titles,
-            @RequestPart("images") List<MultipartFile> images,
+            @RequestPart("titles") String title,
+            @RequestPart("images") MultipartFile image,
             @AuthenticationPrincipal UserPrincipal userPrincipal) {
-        organizationService.createOrganizations(titles, images, userPrincipal);
+        organizationService.createOrganization(title, image, userPrincipal);
         return ResponseEntity.ok(
                 ApiResult.builder()
                         .check(true)
@@ -59,7 +57,6 @@ public class OrganizationController {
                         .build()
         );
     }
-
     @Operation(summary = "조직도 삭제")
     @DeleteMapping("/{organizationId}")
     public ResponseEntity<?> deleteOrganization(@PathVariable Long organizationId,

--- a/src/main/java/depth/mju/council/domain/orgarnization/service/OrganizationService.java
+++ b/src/main/java/depth/mju/council/domain/orgarnization/service/OrganizationService.java
@@ -38,23 +38,19 @@ public class OrganizationService {
     }
 
     @Transactional
-    public void createOrganizations(List<String> titles, List<MultipartFile> images, UserPrincipal userPrincipal) {
-        if (titles.size() != images.size()) {
-            throw new DefaultException(ErrorCode.INVALID_PARAMETER, "제목의 개수와 이미지의 개수가 일치하지 않습니다.");
-        }
+    public void createOrganization(String title, MultipartFile image, UserPrincipal userPrincipal) {
 
         UserEntity user = userRepository.findById(userPrincipal.getId())
                 .orElseThrow(() -> new DefaultException(ErrorCode.USER_NOT_FOUND));
 
-        for (int i = 0; i < titles.size(); i++) {
-            String imgUrl = s3Service.uploadImage(images.get(i));
-            Organization organization = Organization.builder()
-                    .title(titles.get(i))
-                    .imgUrl(imgUrl)
-                    .userEntity(user)
-                    .build();
-            organizationRepository.save(organization);
-        }
+        String imgUrl = s3Service.uploadImage(image);
+        Organization organization = Organization.builder()
+                .title(title)
+                .imgUrl(imgUrl)
+                .userEntity(user)
+                .build();
+        organizationRepository.save(organization);
+
     }
 
     @Transactional
@@ -70,7 +66,6 @@ public class OrganizationService {
             String oldImageName = s3Service.extractImageNameFromUrl(oldImageUrl);
             s3Service.deleteImage(oldImageName);
         }
-
         // 새 이미지 업로드
         String newImageUrl = s3Service.uploadImage(image);
         organization.updateTitleAndImgUrl(title, newImageUrl);

--- a/src/main/java/depth/mju/council/global/config/SecurityConfig.java
+++ b/src/main/java/depth/mju/council/global/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package depth.mju.council.global.config;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -23,7 +24,6 @@ public class SecurityConfig {
 
     private static final String[] WHITE_LIST = {
             "/api/v1/users/**",
-            "/api/v1/**",
             "/",
             "/error",
             "/swagger",
@@ -54,6 +54,8 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests(request -> request
                         .requestMatchers(WHITE_LIST)
+                        .permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/**")
                         .permitAll()
                         .anyRequest()
                         .authenticated() //어떠한 요청이라도 인증 필요


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

- [x] 국별 소개 조회
- [x] 국별 소개 등록
- [x] 국별 소개 수정
- [x] 국별 소개 삭제 
- [x] 조직도 개별 등록으로 변경 (기존엔 여러 개 등록)
- [x] Security Config 변경 (전체 API 허용 -> GET메소드만 허용) 

### 📷 스크린샷
> 작업 화면(피그마, 웹사이트 등) 및 실행 결과를 캡쳐해주세요


## #️⃣ 연관된 이슈
> ex) # 이슈번호
#24 

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 예외 처리를 이렇게 해도 괜찮을까요? / ~~부분 주의 깊게 봐주세요
